### PR TITLE
Add an environment variable

### DIFF
--- a/config/develop/agora.yaml
+++ b/config/develop/agora.yaml
@@ -4,6 +4,7 @@ dependencies:
   - agoradb
 parameters:
   AppDeployBucket: 'org-sagebionetworks-agora-deployment-agora-develop'
+  AppEnv: 'develop'
   AppHealthcheckUrl: '/about'
   AutoScalingMaxSize: '2'
   AutoScalingMinSize: '1'

--- a/config/prod/agora.yaml
+++ b/config/prod/agora.yaml
@@ -4,6 +4,7 @@ dependencies:
   - agoradb
 parameters:
   AppDeployBucket: 'org-sagebionetworks-agora-deployment-agora-prod'
+  AppEnv: 'prod'
   AppHealthcheckUrl: '/about'
   AutoScalingMaxSize: '2'
   AutoScalingMinSize: '1'

--- a/config/staging/agora.yaml
+++ b/config/staging/agora.yaml
@@ -4,6 +4,7 @@ dependencies:
   - agoradb
 parameters:
   AppDeployBucket: 'org-sagebionetworks-agora-deployment-agora-staging'
+  AppEnv: 'staging'
   AppHealthcheckUrl: '/about'
   AutoScalingMaxSize: '2'
   AutoScalingMinSize: '1'

--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -4,6 +4,9 @@ Parameters:
   AppDeployBucket:
     Description: Bucket where beanstalk deploys apps from
     Type: String
+  AppEnv:
+    Type: String
+    Description: The application environment
   AppHealthcheckUrl:
     Type: String
     Description: The AWS EB health check path
@@ -315,6 +318,9 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: MONGODB_PORT
           Value: !Ref MongodbPort
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: APP_ENV
+          Value: !Ref AppEnv
   BeanstalkEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:


### PR DESCRIPTION
Setup an `APP_ENV` environment variable to allow agora app to
determin which parameters to get from the AWS SSM.

Our parameters contain the following prefixes:
/agora-develop/..
/agora-staging/..
/agora-prod/..