### PR TITLE
Enable load balancer access logs

### DIFF
--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -134,6 +134,27 @@ Resources:
     Type: 'AWS::S3::Bucket'
     Properties:
       BucketName: !Ref AppDeployBucket
+  LoadBalancerAccessLogsBucket:
+    Type: 'AWS::S3::Bucket'
+  LoadBalancerAccessLogsBucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Properties:
+      Bucket: !Ref LoadBalancerAccessLogsBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ModAccess
+            Action:
+              - 's3:PutObject'
+            Effect: Allow
+            Resource:
+              - !Join
+                - ''
+                - - !GetAtt LoadBalancerAccessLogsBucket.Arn
+                  - '/*'
+            Principal:
+              AWS:
+                - 127311923021
   S3ManagedPolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
@@ -294,6 +315,12 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:environment'
           OptionName: LoadBalancerType
           Value: 'application'
+        - Namespace: 'aws:elbv2:loadbalancer'
+          OptionName: AccessLogsS3Bucket
+          Value: !Ref LoadBalancerAccessLogsBucket
+        - Namespace: 'aws:elbv2:loadbalancer'
+          OptionName: AccessLogsS3Enabled
+          Value: 'true'
         # use manually generated SSL certificate '*.ampadportal.org'
         - Namespace: 'aws:elbv2:listener:443'
           OptionName: SSLCertificateArns


### PR DESCRIPTION
Previous PR[1] attempt failed. New attempt to enable LB access logs.

Security best practice is to capture logs for Elastic Load Balancing
with detailed information about requests sent to the Load Balancer.

Fixes issue: Sage-Bionetworks/Agora#569

[1] https://github.com/Sage-Bionetworks/Agora-infra/pull/27