### PR TITLE
change deployment from rolling to immutable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ install:
 script:
 - ./validate-templates.sh || travis_terminate 1
 - sceptre --var "profile=default" --var "region=us-east-1" launch-env common
-- sceptre --var "profile=default" --var "region=us-east-1" launch-env $TRAVIS_BRANCH
+- travis_wait 30 sceptre --var "profile=default" --var "region=us-east-1" launch-env $TRAVIS_BRANCH
 

--- a/config/develop/agora.yaml
+++ b/config/develop/agora.yaml
@@ -8,6 +8,8 @@ parameters:
   AppHealthcheckUrl: '/about'
   AutoScalingMaxSize: '2'
   AutoScalingMinSize: '1'
+  EbDeploymentPolicy: 'Immutable'
+  EbRollingUpdateType: 'Immutable'
   SnsBounceNotificationEndpoint: 'agora-develop-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-develop@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.5.4 running Node.js'

--- a/config/prod/agora.yaml
+++ b/config/prod/agora.yaml
@@ -8,6 +8,8 @@ parameters:
   AppHealthcheckUrl: '/about'
   AutoScalingMaxSize: '6'
   AutoScalingMinSize: '3'
+  EbDeploymentPolicy: 'Immutable'
+  EbRollingUpdateType: 'Immutable'
   SnsBounceNotificationEndpoint: 'agora-prod-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-prod@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.5.4 running Node.js'

--- a/config/staging/agora.yaml
+++ b/config/staging/agora.yaml
@@ -8,6 +8,8 @@ parameters:
   AppHealthcheckUrl: '/about'
   AutoScalingMaxSize: '4'
   AutoScalingMinSize: '2'
+  EbDeploymentPolicy: 'Immutable'
+  EbRollingUpdateType: 'Immutable'
   SnsBounceNotificationEndpoint: 'agora-staging-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-staging@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.5.4 running Node.js'


### PR DESCRIPTION
Immutable[1] is the only type of update that will automatically
rollback if a deployment fails. Set update to immutable for
both application and environment updates

[1] https://docs.aws.amazon.com//elasticbeanstalk/latest/dg/using-features.rolling-version-deploy.html