### PR TITLE
Setup a bastian host for agora

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
 - ./validate-templates.sh || travis_terminate 1
 - sceptre --var "profile=default" --var "region=us-east-1" launch-env common
 - travis_wait 45 sceptre --var "profile=default" --var "region=us-east-1" launch-env $TRAVIS_BRANCH
-
+- sceptre --var "profile=default" --var "region=us-east-1" launch-env misc

--- a/config/misc/agora-bastian.yaml
+++ b/config/misc/agora-bastian.yaml
@@ -3,9 +3,9 @@ template_path: templates/bastian.yaml
 stack_name: agora-bastian
 parameters:
   # The Sage deparment for this resource
-  Department: "Systems Biology"
+  Department: "SysBio"
   # The Sage project this resource will be used for
-  Project: "Agora"
+  Project: "amp-ad"
   # The resource owner
   OwnerEmail: "khai.do@sagebase.org"
   # EC2 instance type (available types https://aws.amazon.com/ec2/instance-types/)
@@ -14,6 +14,8 @@ parameters:
   VpcSubnet: "PublicSubnet"
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
   KeyName: "toptal"
+  # (Optional) ID of the base AMI (supported distros: AWS linux)
+  AMIId: ami-003ed7eaef0321c8f     # AMI with mongo db tools
 
    # Integration with our jumpcloud directory service (do not change)
   JcConnectKey: !ssm /infra/JcConnectKey


### PR DESCRIPTION
The bastian host is used for debugging and updating the database
with new data.  It is used by the agora-data-manager[1]

[1] https://github.com/Sage-Bionetworks/agora-data-manager