### PR TITLE
[IT-435] upgrade to use Sceptre ver 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,8 +112,7 @@ git-crypt.key
 !.elasticbeanstalk/*.global.yml
 
 # sceptre artifacts
-remote-templates
-resolvers
+templates/remote
 
 # lambda artifacts
 lambdas/*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: python
-python: 3.5
+python: 3.6
 cache: pip
 fast_finish: true
 branches:
@@ -9,11 +9,13 @@ branches:
   - staging
   - prod
 install:
-  - pip install cfn-lint
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
-  - ./setup_sceptre.sh || travis_terminate 1
+  - pip install cfn-lint
+  - pip install git+git://github.com/zaro0508/sceptre@issue-586
+  - pip install git+git://github.com/zaro0508/sceptre-ssm-resolver.git
+  - pip install git+git://github.com/zaro0508/sceptre-date-resolver.git
 stages:
   - name: validate
   - name: deploy
@@ -21,9 +23,9 @@ stages:
 jobs:
   include:
     - stage: validate
-      script: cfn-lint ./templates/**/*.yaml
+      script: cfn-lint ./templates/**/*
     - stage: deploy
       script:
-        - sceptre --var "profile=default" --var "region=us-east-1" launch-env common
-        - travis_wait 45 sceptre --var "profile=default" --var "region=us-east-1" launch-env $TRAVIS_BRANCH
-        - sceptre --var "profile=default" --var "region=us-east-1" launch-env misc
+        - sceptre launch common --yes
+        - travis_wait 45 sceptre launch $TRAVIS_BRANCH --yes
+        - sceptre launch misc --yes

--- a/config/common/agora.yaml
+++ b/config/common/agora.yaml
@@ -1,2 +1,2 @@
-template_path: templates/beanstalk-common.yaml
+template_path: beanstalk-common.yaml
 stack_name: agora-common

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,3 +3,4 @@ profile: {{ var.profile | default("default") }}
 region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-114n2ojlbvj21
 template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}
+admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"

--- a/config/develop/agora.yaml
+++ b/config/develop/agora.yaml
@@ -1,4 +1,4 @@
-template_path: templates/beanstalk.yaml
+template_path: beanstalk.yaml
 stack_name: agora-develop
 dependencies:
   - agoradb

--- a/config/develop/agoradb.yaml
+++ b/config/develop/agoradb.yaml
@@ -1,4 +1,4 @@
-template_path: templates/mongodb.yaml
+template_path: mongodb.yaml
 stack_name: agoradb-develop
 parameters:
   KeyPairName: 'toptal'

--- a/config/misc/agora-bastian.yaml
+++ b/config/misc/agora-bastian.yaml
@@ -1,5 +1,5 @@
 # Provision an EC2 bastian host for agora
-template_path: templates/bastian.yaml
+template_path: bastian.yaml
 stack_name: agora-bastian
 parameters:
   # The Sage deparment for this resource

--- a/config/prod/agora.yaml
+++ b/config/prod/agora.yaml
@@ -1,4 +1,4 @@
-template_path: templates/beanstalk.yaml
+template_path: beanstalk.yaml
 stack_name: agora-prod
 dependencies:
   - agoradb

--- a/config/prod/agoradb.yaml
+++ b/config/prod/agoradb.yaml
@@ -1,4 +1,4 @@
-template_path: templates/mongodb.yaml
+template_path: mongodb.yaml
 stack_name: agoradb-prod
 parameters:
   KeyPairName: 'toptal'

--- a/config/staging/agora.yaml
+++ b/config/staging/agora.yaml
@@ -1,4 +1,4 @@
-template_path: templates/beanstalk.yaml
+template_path: beanstalk.yaml
 stack_name: agora-staging
 dependencies:
   - agoradb

--- a/config/staging/agoradb.yaml
+++ b/config/staging/agoradb.yaml
@@ -1,4 +1,4 @@
-template_path: templates/mongodb.yaml
+template_path: mongodb.yaml
 stack_name: agoradb-staging
 parameters:
   KeyPairName: 'toptal'


### PR DESCRIPTION
Upgrade from Sceptre 1.x to 2.x because V1 is end of life[1].
Followed the migration guide[2] to do the upgrade.

[1] cloudreach/sceptre#593
[2] https://github.com/cloudreach/sceptre/wiki/Migration-Guide:-V1-to-V2