### PR TITLE
Set max EB deployments

### DIFF
--- a/templates/beanstalk-common.yaml
+++ b/templates/beanstalk-common.yaml
@@ -13,10 +13,36 @@ Parameters:
     Type: String
     Default: 'ampadscicomp.org'
 Resources:
+  BeanstalkServiceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - elasticbeanstalk.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                sts:ExternalId: elasticbeanstalk
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth'
+        - 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService'
   BeanstalkApplication:
     Type: 'AWS::ElasticBeanstalk::Application'
     Properties:
       ApplicationName: !Ref EbAppName
+      ResourceLifecycleConfig:
+        ServiceRole: !GetAtt BeanstalkServiceRole.Arn
+        VersionLifecycleConfig:
+          MaxAgeRule:
+            DeleteSourceFromS3: true
+            Enabled: true
+            MaxAgeInDays: 30
   SSLCertificate:
     Type: AWS::CertificateManager::Certificate
     Properties:
@@ -97,6 +123,10 @@ Outputs:
     Value: !Ref BeanstalkApplication
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-BeanstalkAppName'
+  BeanstalkServiceRole:
+    Value: !Ref BeanstalkServiceRole
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BeanstalkServiceRole'
   HostedZoneId:         # Existing hosted zone id
     Value: ZS9A6IHRRJXMS
     Export:

--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -311,7 +311,7 @@ Resources:
           Value: !Ref EbDeploymentPolicy
         - Namespace: 'aws:elasticbeanstalk:environment'
           OptionName: ServiceRole
-          Value: !Ref BeanstalkServiceRole
+          Value: !ImportValue us-east-1-agora-common-BeanstalkServiceRole
         - Namespace: 'aws:elasticbeanstalk:environment'
           OptionName: LoadBalancerType
           Value: 'application'
@@ -360,25 +360,6 @@ Resources:
       Tier:
         Name: WebServer
         Type: Standard
-  BeanstalkServiceRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - elasticbeanstalk.amazonaws.com
-            Action:
-              - 'sts:AssumeRole'
-            Condition:
-              StringEquals:
-                sts:ExternalId: elasticbeanstalk
-      Path: /
-      ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth'
-        - 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService'
   EC2ServiceRole:
     Type: 'AWS::IAM::Role'
     Properties:


### PR DESCRIPTION
AWS enforces a limit on the number of EB application versions that it
stores[1].  We enforce our own limit so we don't run into this error.

"You cannot have more than 500 Application Versions. Either remove some
Application Versions or request a limit increase."

[1] https://forums.aws.amazon.com/thread.jspa?threadID=159072