### PR TITLE
Enable auto patching of node

### DIFF
--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -360,6 +360,18 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: DISABLE_OPENCOLLECTIVE
           Value: !Ref DisableOpencollective
+        - Namespace: 'aws:elasticbeanstalk:managedactions'
+          OptionName: 'ManagedActionsEnabled'
+          Value: 'true'
+        - Namespace: 'aws:elasticbeanstalk:managedactions'
+          OptionName: 'PreferredStartTime'
+          Value: 'Fri:00:00'
+        - Namespace: 'aws:elasticbeanstalk:managedactions:platformupdate'
+          OptionName: 'UpdateLevel'
+          Value: 'minor'
+        - Namespace: 'aws:elasticbeanstalk:managedactions:platformupdate'
+          OptionName: 'InstanceRefreshEnabled'
+          Value: 'true'
   BeanstalkEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:


### PR DESCRIPTION
This will allow Beanstalk to automatically patch the Node JS platform
versions[1] for Agora.  It will also provision new instances weekly.

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-platform-update-managed.html#environment-platform-update-managed-namespace