### PR TITLE
Enable enhanced health reporting

### DIFF
--- a/config/develop/agora.yaml
+++ b/config/develop/agora.yaml
@@ -8,6 +8,7 @@ parameters:
   AppHealthcheckUrl: '/about'
   AutoScalingMaxSize: '2'
   AutoScalingMinSize: '1'
+  EbHealthReportingSystem: 'enhanced'
   SnsBounceNotificationEndpoint: 'agora-develop-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-develop@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.5.4 running Node.js'

--- a/config/staging/agora.yaml
+++ b/config/staging/agora.yaml
@@ -8,6 +8,7 @@ parameters:
   AppHealthcheckUrl: '/about'
   AutoScalingMaxSize: '4'
   AutoScalingMinSize: '2'
+  EbHealthReportingSystem: 'enhanced'
   SnsBounceNotificationEndpoint: 'agora-staging-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-staging@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.5.4 running Node.js'


### PR DESCRIPTION
We want to enable beanstalk managed platform updates but that
feature requires enabling enhanced health reporting first.