### PR TITLE
[AG-42] fix deployment error

### DIFF
--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -272,6 +272,9 @@ Resources:
         - Namespace: 'aws:autoscaling:launchconfiguration'
           OptionName: SecurityGroups
           Value: !Ref MongodbAccessSecurityGroup
+        - Namespace: 'aws:autoscaling:launchconfiguration'
+          OptionName: RootVolumeSize
+          Value: '32'
         - Namespace: 'aws:autoscaling:updatepolicy:rollingupdate'
           OptionName: RollingUpdateEnabled
           Value: 'true'


### PR DESCRIPTION
Beanstalk was failing to deploy because there was not enough disk space
in the beanstalk provided instance. By default Beanstalk provisions an
8GB EBS volume. To fix we need to increase the disk space to 32GB

Failure:
```
  [root@ip-10-5-51-92] cd /opt/elasticbeanstalk/hooks/appdeploy/pre
  [root@ip-10-5-51-92 pre] ./20unzip.sh
  ..
  ..
  inflating: /tmp/deployment/application/node_modules/typedoc/node_modules/typescript/lib/lib.esnext.intl.d.ts
  inflating: /tmp/deployment/application/node_modules/typedoc/node_modules/typescript/lib/lib.d.ts
  inflating: /tmp/deployment/application/node_modules/typedoc/node_modules/typescript/lib/tsc.js
/tmp/deployment/application/node_modules/typedoc/node_modules/typescript/lib/tsc.js:  write error (disk full?).  Continue? (y/n/^C) n

  warning:  /tmp/deployment/application/node_modules/typedoc/node_modules/typescript/lib/tsc.js is probably truncated
  [root@ip-10-5-51-92 pre]# df -h
  Filesystem      Size  Used Avail Use% Mounted on
  devtmpfs        1.9G   68K  1.9G   1% /dev
  tmpfs           1.9G     0  1.9G   0% /dev/shm
  /dev/nvme0n1p1  7.9G  7.8G     0 100% /
```