### PR TITLE
[AG-46] Add SSL certificate

### DIFF
--- a/config/develop/agora-extras.yaml
+++ b/config/develop/agora-extras.yaml
@@ -1,0 +1,7 @@
+template_path: beanstalk-extras.yaml
+stack_name: agora-develop-extras.yaml
+dependencies:
+  - develop/agora.yaml
+parameters:
+  ListenerArn: "arn:aws:elasticloadbalancing:us-east-1:055273631518:loadbalancer/app/awseb-AWSEB-R8AL4TAACN8K/f1f0223eb67f6f12"
+  CertificateArn: "arn:aws:acm:us-east-1:055273631518:certificate/412c0ea4-8123-48dd-b0af-608558cbb902"   # *.ampadportal.org

--- a/config/prod/agora-extras.yaml
+++ b/config/prod/agora-extras.yaml
@@ -1,0 +1,7 @@
+template_path: beanstalk-extras.yaml
+stack_name: agora-prod-extras.yaml
+dependencies:
+  - prod/agora.yaml
+parameters:
+  ListenerArn: "arn:aws:elasticloadbalancing:us-east-1:055273631518:loadbalancer/app/awseb-AWSEB-1AEIEZ8KICCU3/f27722898ec2b53f"
+  CertificateArn: "arn:aws:acm:us-east-1:055273631518:certificate/412c0ea4-8123-48dd-b0af-608558cbb902"   # *.ampadportal.org

--- a/config/staging/agora-extras.yaml
+++ b/config/staging/agora-extras.yaml
@@ -1,0 +1,7 @@
+template_path: beanstalk-extras.yaml
+stack_name: agora-staging-extras.yaml
+dependencies:
+  - staging/agora.yaml
+parameters:
+  ListenerArn: "arn:aws:elasticloadbalancing:us-east-1:055273631518:loadbalancer/app/awseb-AWSEB-1JONRM5UT0GXI/5dc2d7ba9a4f4cda"
+  CertificateArn: "arn:aws:acm:us-east-1:055273631518:certificate/412c0ea4-8123-48dd-b0af-608558cbb902"   # *.ampadportal.org

--- a/templates/beanstalk-extras.yaml
+++ b/templates/beanstalk-extras.yaml
@@ -1,0 +1,22 @@
+# This creates and configures resources for Elastic Beanstalk.
+# This template is used to setup extra things after deploying beanstalk apps
+AWSTemplateFormatVersion: 2010-09-09
+Description: Beanstalk ELB resources and configs
+Parameters:
+  ListenerArn:
+    Description: ARN of the ELB listern
+    Type: String
+  CertificateArn:
+    Description: ARN of the SSL Certificate
+    Type: String
+    Default: 'ampadscicomp.org'
+Resources:
+  # Cloudforamtion does not support adding multiple certificats in Beanstalk
+  # with aws:elbv2:listener:443 -> SSLCertificateArns therefore we configure
+  # the Beanstalk ELB with a CFN resource in a separate step
+  SSLCertificate:
+    Type: "AWS::ElasticLoadBalancingV2::ListenerCertificate"
+    Properties:
+      ListenerArn: !Ref ListenerArn
+      Certificates:
+        - CertificateArn: !Ref CertificateArn


### PR DESCRIPTION
Add *.ampadportal.org cert to Beanstalk ELB.
Multiple certs are not supported in beanstalk so we need to
use workaround https://github.com/awsdocs/aws-cloudformation-user-guide/issues/153#issuecomment-444714509

This depends on PR https://github.com/Sage-Bionetworks/Agora-infra/pull/59