### PR TITLE
[AG-61] Montoring for Agora single instance DB

### DIFF
--- a/config/prod/lambda-mongo-health-check.yaml
+++ b/config/prod/lambda-mongo-health-check.yaml
@@ -1,0 +1,21 @@
+template_path: "remote/lambda-mongo-health-check.yaml"
+stack_name: "agora-lambda-mongo-health-check"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/agoradb.yaml"
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-mongo-health-check/master/lambda-mongo-health-check.yaml --create-dirs -o templates/remote/lambda-mongo-health-check.yaml"
+parameters:
+  Host: !stack_output_external agoradb-prod::PrimaryReplicaNodeIp
+  Database: "agora"
+  DbUser: !ssm /agora-prod/MongodbUsername
+  DbPassword: !ssm /agora-prod/MongodbPassword
+  SubnetIds:
+    - !stack_output_external computevpc::PrivateSubnet
+  SecurityGroupIds:
+    - !stack_output_external agoradb-prod::MongoDBServerAccessSecurityGroup
+  Schedule: "rate(1 hour)"

--- a/config/prod/notifications.yaml
+++ b/config/prod/notifications.yaml
@@ -1,5 +1,5 @@
 template_path: "notifications.yaml"
-stack_name: "agora-notifications"
+stack_name: "agora-prod-notifications"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"

--- a/config/prod/notifications.yaml
+++ b/config/prod/notifications.yaml
@@ -1,0 +1,10 @@
+template_path: "notifications.yaml"
+stack_name: "agora-notifications"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/lambda-mongo-health-check.yaml"
+parameters:
+  NotificationEndpoint: "agora-prod@sagebase.org"

--- a/templates/notifications.yaml
+++ b/templates/notifications.yaml
@@ -1,0 +1,41 @@
+Description: Agora notifications
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  NotificationEndpoint:
+    Type: String
+    Description: Email address for notifications
+Resources:
+  SnsTopic:
+    Type: "AWS::SNS::Topic"
+    Properties:
+      Subscription:
+        -
+          Endpoint: !Ref NotificationEndpoint
+          Protocol: "email"
+  LogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      RetentionInDays: 14
+  ErrorMetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    Properties:
+      LogGroupName: !Ref LogGroup
+      FilterPattern: 'ERROR'
+      MetricTransformations:
+        -
+          MetricValue: "1"
+          MetricNamespace: !Sub '${AWS::StackName}/Errors'
+          MetricName: !Sub '${AWS::StackName}-Error'
+  ErrorAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmActions:
+        - !Ref SnsTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Ref ErrorMetricFilter
+      Namespace: !Sub '${AWS::StackName}/Errors'
+      Period: 3600
+      Statistic: "Sum"
+      Threshold: 4
+      TreatMissingData: "notBreaching"


### PR DESCRIPTION
Setup a lambda to monitor the Agora db.  The lambda checks the
DB every hour to verify whether it's still accessible.  Results
are sent to cloudwatch.  A notification is setup in cloudwatch
to detect connection errors.  If there are 4 consecutive connection
failures an alarm is sent to the agora-prod google group.

Users must subscribe to the agora-prod google group to receive
notifications.

Note: this is only setup to monitor the prod db instance