### PR TITLE
Change EC2 keyname reference in all environments

### DIFF
--- a/config/develop/agora.yaml
+++ b/config/develop/agora.yaml
@@ -13,6 +13,6 @@ parameters:
   SnsNotificationEndpoint: 'agora-develop@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.13.0 running Node.js'
   EC2InstanceType: 't3.medium'
-  EC2KeyName: 'agora-travis'
+  EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-develop::PrimaryReplicaNodeIp
   MongodbAccessSecurityGroup: !stack_output_external agoradb-develop::MongoDBServerAccessSecurityGroup

--- a/config/develop/agora.yaml
+++ b/config/develop/agora.yaml
@@ -13,6 +13,6 @@ parameters:
   SnsNotificationEndpoint: 'agora-develop@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.13.0 running Node.js'
   EC2InstanceType: 't3.medium'
-  EC2KeyName: 'toptal'
+  EC2KeyName: 'agora-travis'
   MongodbHost: !stack_output_external agoradb-develop::PrimaryReplicaNodeIp
   MongodbAccessSecurityGroup: !stack_output_external agoradb-develop::MongoDBServerAccessSecurityGroup

--- a/config/develop/agoradb.yaml
+++ b/config/develop/agoradb.yaml
@@ -1,7 +1,7 @@
 template_path: mongodb.yaml
 stack_name: agoradb-develop
 parameters:
-  KeyPairName: 'agora-travis'
+  KeyPairName: 'agora-access'
   VPC: !stack_output_external computevpc::VPCId
   PrimaryNodeSubnet: !stack_output_external computevpc::PrivateSubnet
   Secondary0NodeSubnet: !stack_output_external computevpc::PrivateSubnet1

--- a/config/develop/agoradb.yaml
+++ b/config/develop/agoradb.yaml
@@ -1,7 +1,7 @@
 template_path: mongodb.yaml
 stack_name: agoradb-develop
 parameters:
-  KeyPairName: 'toptal'
+  KeyPairName: 'agora-travis'
   VPC: !stack_output_external computevpc::VPCId
   PrimaryNodeSubnet: !stack_output_external computevpc::PrivateSubnet
   Secondary0NodeSubnet: !stack_output_external computevpc::PrivateSubnet1

--- a/config/misc/agora-bastian.yaml
+++ b/config/misc/agora-bastian.yaml
@@ -13,6 +13,6 @@ parameters:
   # Name of an existing VPC subnet to run the instance in
   VpcSubnet: "PublicSubnet"
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
-  KeyName: "toptal"
+  KeyName: "agora-travis"
   # (Optional) ID of the base AMI (supported distros: AWS linux)
   AMIId: ami-003ed7eaef0321c8f     # AMI with mongo db tools

--- a/config/prod/agora.yaml
+++ b/config/prod/agora.yaml
@@ -15,6 +15,6 @@ parameters:
   SnsNotificationEndpoint: 'agora-prod@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.13.0 running Node.js'
   EC2InstanceType: 't3.medium'
-  EC2KeyName: 'toptal'
+  EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-prod::PrimaryReplicaNodeIp
   MongodbAccessSecurityGroup: !stack_output_external agoradb-prod::MongoDBServerAccessSecurityGroup

--- a/config/prod/agoradb.yaml
+++ b/config/prod/agoradb.yaml
@@ -1,7 +1,7 @@
 template_path: mongodb.yaml
 stack_name: agoradb-prod
 parameters:
-  KeyPairName: 'agora-travis'
+  KeyPairName: 'agora-access'
   VPC: !stack_output_external computevpc::VPCId
   PrimaryNodeSubnet: !stack_output_external computevpc::PrivateSubnet
   Secondary0NodeSubnet: !stack_output_external computevpc::PrivateSubnet1

--- a/config/prod/agoradb.yaml
+++ b/config/prod/agoradb.yaml
@@ -1,7 +1,7 @@
 template_path: mongodb.yaml
 stack_name: agoradb-prod
 parameters:
-  KeyPairName: 'toptal'
+  KeyPairName: 'agora-travis'
   VPC: !stack_output_external computevpc::VPCId
   PrimaryNodeSubnet: !stack_output_external computevpc::PrivateSubnet
   Secondary0NodeSubnet: !stack_output_external computevpc::PrivateSubnet1

--- a/config/staging/agora.yaml
+++ b/config/staging/agora.yaml
@@ -13,6 +13,6 @@ parameters:
   SnsNotificationEndpoint: 'agora-staging@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.13.0 running Node.js'
   EC2InstanceType: 't3.medium'
-  EC2KeyName: 'toptal'
+  EC2KeyName: 'agora-travis'
   MongodbHost: !stack_output_external agoradb-staging::PrimaryReplicaNodeIp
   MongodbAccessSecurityGroup: !stack_output_external agoradb-staging::MongoDBServerAccessSecurityGroup

--- a/config/staging/agora.yaml
+++ b/config/staging/agora.yaml
@@ -13,6 +13,6 @@ parameters:
   SnsNotificationEndpoint: 'agora-staging@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.13.0 running Node.js'
   EC2InstanceType: 't3.medium'
-  EC2KeyName: 'agora-travis'
+  EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-staging::PrimaryReplicaNodeIp
   MongodbAccessSecurityGroup: !stack_output_external agoradb-staging::MongoDBServerAccessSecurityGroup

--- a/config/staging/agoradb.yaml
+++ b/config/staging/agoradb.yaml
@@ -1,7 +1,7 @@
 template_path: mongodb.yaml
 stack_name: agoradb-staging
 parameters:
-  KeyPairName: 'toptal'
+  KeyPairName: 'agora-travis'
   VPC: !stack_output_external computevpc::VPCId
   PrimaryNodeSubnet: !stack_output_external computevpc::PrivateSubnet
   Secondary0NodeSubnet: !stack_output_external computevpc::PrivateSubnet1

--- a/config/staging/agoradb.yaml
+++ b/config/staging/agoradb.yaml
@@ -1,7 +1,7 @@
 template_path: mongodb.yaml
 stack_name: agoradb-staging
 parameters:
-  KeyPairName: 'agora-travis'
+  KeyPairName: 'agora-access'
   VPC: !stack_output_external computevpc::VPCId
   PrimaryNodeSubnet: !stack_output_external computevpc::PrivateSubnet
   Secondary0NodeSubnet: !stack_output_external computevpc::PrivateSubnet1


### PR DESCRIPTION
This will update the EC2 key used between Travis, the bastion, and db instances. The new private key is in the password vault under Shared-Admin/AWS Agora.