### PR TITLE
IT-1337: Change instance type for staging

### DIFF
--- a/config/staging/agora.yaml
+++ b/config/staging/agora.yaml
@@ -10,7 +10,7 @@ parameters:
   SnsBounceNotificationEndpoint: 'agora-staging-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-staging@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.13.0 running Node.js'
-  EC2InstanceType: 't3.medium'
+  EC2InstanceType: 't3.large'
   EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-staging::PrimaryReplicaNodeIp
   MongodbAccessSecurityGroup: !stack_output_external agoradb-staging::MongoDBServerAccessSecurityGroup


### PR DESCRIPTION
The failure appears to be caused by an out-of-memory error. This PR changes the type of instance to 't3.large' to get around it.