### PR TITLE
AG-165: Revert timeout and set instance type to large for all environment

### DIFF
--- a/config/develop/agora.yaml
+++ b/config/develop/agora.yaml
@@ -10,8 +10,7 @@ parameters:
   SnsBounceNotificationEndpoint: 'agora-develop-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-develop@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.13.0 running Node.js'
-  EC2InstanceType: 't3.medium'
+  EC2InstanceType: 't3.large'
   EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-develop::PrimaryReplicaNodeIp
   MongodbAccessSecurityGroup: !stack_output_external agoradb-develop::MongoDBServerAccessSecurityGroup
-  BeanstalkDeployTimeout: '1000'

--- a/config/prod/agora.yaml
+++ b/config/prod/agora.yaml
@@ -12,8 +12,7 @@ parameters:
   SnsBounceNotificationEndpoint: 'agora-prod-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-prod@sagebase.org'
   EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.13.0 running Node.js'
-  EC2InstanceType: 't3.medium'
+  EC2InstanceType: 't3.large'
   EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-prod::PrimaryReplicaNodeIp
   MongodbAccessSecurityGroup: !stack_output_external agoradb-prod::MongoDBServerAccessSecurityGroup
-  BeanstalkDeployTimeout: '1000'

--- a/config/staging/agora.yaml
+++ b/config/staging/agora.yaml
@@ -14,4 +14,3 @@ parameters:
   EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-staging::PrimaryReplicaNodeIp
   MongodbAccessSecurityGroup: !stack_output_external agoradb-staging::MongoDBServerAccessSecurityGroup
-  BeanstalkDeployTimeout: '1000'

--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -80,9 +80,6 @@ Parameters:
   MongodbAccessSecurityGroup:
     Type: String
     Description: Security group with access to MongoDB servers
-  BeanstalkDeployTimeout:
-    Type: String
-    Description: Beanstalk timeout to execute deployment
   Department:
     Description: 'The department for this resource'
     Type: String
@@ -299,9 +296,6 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:command'
           OptionName: DeploymentPolicy
           Value: !Ref EbDeploymentPolicy
-        - Namespace: 'aws:elasticbeanstalk:command'
-          OptionName: Timeout
-          Value: !Ref BeanstalkDeployTimeout
         - Namespace: 'aws:elasticbeanstalk:environment'
           OptionName: ServiceRole
           Value: !ImportValue us-east-1-agora-common-BeanstalkServiceRole


### PR DESCRIPTION
1. Revert deployment timeout change in this [PR](https://github.com/Sage-Bionetworks/Agora-infra/pull/99) based on code review comment in this [PR](https://github.com/Sage-Bionetworks/Agora/pull/857)
2. Change instance type to `t3.large` for dev and prod branches. 