### PR TITLE
[IT-1448] Update to latest EB Node.js 4.x solution stack

### DIFF
--- a/config/develop/agora.yaml
+++ b/config/develop/agora.yaml
@@ -10,7 +10,7 @@ parameters:
   EbDeploymentPolicy: 'RollingWithAdditionalBatch'
   SnsBounceNotificationEndpoint: 'agora-develop-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-develop@sagebase.org'
-  EbSolutionStackName: '64bit Amazon Linux 2 v5.4.5 running Node.js 12'
+  EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.17.9 running Node.js'
   EC2InstanceType: 't3.large'
   EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-develop::PrimaryReplicaNodeIp

--- a/config/prod/agora.yaml
+++ b/config/prod/agora.yaml
@@ -10,7 +10,7 @@ parameters:
   EbDeploymentPolicy: 'RollingWithAdditionalBatch'
   SnsBounceNotificationEndpoint: 'agora-prod-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-prod@sagebase.org'
-  EbSolutionStackName: '64bit Amazon Linux 2 v5.4.5 running Node.js 12'
+  EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.17.9 running Node.js'
   EC2InstanceType: 't3.large'
   EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-prod::PrimaryReplicaNodeIp

--- a/config/staging/agora.yaml
+++ b/config/staging/agora.yaml
@@ -10,7 +10,7 @@ parameters:
   EbDeploymentPolicy: 'RollingWithAdditionalBatch'
   SnsBounceNotificationEndpoint: 'agora-staging-bounce-notifications@sagebase.org'
   SnsNotificationEndpoint: 'agora-staging@sagebase.org'
-  EbSolutionStackName: '64bit Amazon Linux 2 v5.4.5 running Node.js 12'
+  EbSolutionStackName: '64bit Amazon Linux 2018.03 v4.17.9 running Node.js'
   EC2InstanceType: 't3.large'
   EC2KeyName: 'agora-access'
   MongodbHost: !stack_output_external agoradb-staging::PrimaryReplicaNodeIp


### PR DESCRIPTION
Since agora is currently using nodejs 4.x platform version, beanstalk
only allows upating the current deployment to the latest major patch
version of the 4.x platform, which i have done.  Agora is now running
on the latest AWS supported 4.x Nodejs platform version which is
ver 4.17.9 and that includes nodejs 12.22.3 and nginx 1.18.0.

https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platform-history-nodejs.html