### PR TITLE
[IT-1466] Use cryptographically strong TLS protocol

### DIFF
--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -316,11 +316,8 @@ Resources:
           OptionName: Protocol
           Value: HTTPS
         # ELB cipher and TLS protocol versions
-        - Namespace: 'aws:elb:listener:443'
-          OptionName: PolicyNames
-          Value: TLSHighPolicy
-        - Namespace:  'aws:elb:policies:TLSHighPolicy'
-          OptionName: SSLReferencePolicy
+        - Namespace: 'aws:elbv2:listener:443'
+          OptionName: SSLPolicy
           Value: ELBSecurityPolicy-TLS-1-2-2017-01
         - Namespace: 'aws:elasticbeanstalk:environment:process:default'
           OptionName: Protocol

--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -315,6 +315,13 @@ Resources:
         - Namespace: 'aws:elbv2:listener:443'
           OptionName: Protocol
           Value: HTTPS
+        # ELB cipher and TLS protocol versions
+        - Namespace: 'aws:elb:listener:443'
+          OptionName: PolicyNames
+          Value: TLSHighPolicy
+        - Namespace:  'aws:elb:policies:TLSHighPolicy'
+          OptionName: SSLReferencePolicy
+          Value: ELBSecurityPolicy-TLS-1-2-2017-01
         - Namespace: 'aws:elasticbeanstalk:environment:process:default'
           OptionName: Protocol
           Value: 'HTTP'


### PR DESCRIPTION
By default AWS load balancers use TLSv1.0. Our security auditor
recommends disabling the use of TLSv1.0 protocol in favor of a
cryptographically stronger TLSv1.2 protocol.

Note- TLS1.0 is compatible with a broader set of clients
(such as web browsers, mobile devices, and point-of-sale systems).

References:
https://aws.amazon.com/blogs/security/how-to-control-tls-ciphers-in-your-aws-elastic-beanstalk-application-by-using-aws-cloudformation/
https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html