### PR TITLE
Pin lambda to a version

### DIFF
--- a/config/prod/lambda-mongo-health-check.yaml
+++ b/config/prod/lambda-mongo-health-check.yaml
@@ -1,13 +1,11 @@
 template:
-  path: "remote/lambda-mongo-health-check.yaml"
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-mongo-health-check/0.1.0/lambda-mongo-health-check.yaml"
 stack_name: "agora-lambda-mongo-health-check"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
   OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-mongo-health-check/master/lambda-mongo-health-check.yaml --create-dirs -o templates/remote/lambda-mongo-health-check.yaml"
 parameters:
   Host: !stack_output_external agoradb-prod::PrimaryReplicaNodeIp
   Database: "agora"


### PR DESCRIPTION
* Pin lambda-mongo-health-check[1] dependency to a specific version to be more
stable.
* Change to using sceptre template handler instead of hooks.

[1] https://github.com/Sage-Bionetworks-IT/lambda-mongo-health-check